### PR TITLE
Add link to ML online courses by Classpert

### DIFF
--- a/README-pt-BR.md
+++ b/README-pt-BR.md
@@ -203,6 +203,10 @@ Cada dia eu pego um assunto da lista abaixo, leia de capa a capa, tome nota, fa√
 	- [Coursera Machine Learning review](https://rayli.net/blog/data/coursera-machine-learning-review/)
 	- [Coursera: Machine Learning Roadmap](https://metacademy.org/roadmaps/cjrd/coursera_ml_supplement)
 
+## Recursos
+
+- [Cursos Online de Machine Learning](https://pt-br.classpert.com/machine-learning)
+
 ## Pesquisas
 - [ ] [Machine Learning for Developers](https://xyclade.github.io/MachineLearning/)
 - [ ] [Machine Learning Advice for Developers](https://dev.to/thealexlavin/machine-learning-advice-for-developers)

--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Each day I take one subject from the list below, read it cover to cover, take no
 - [Awesome Graph Classification](https://github.com/benedekrozemberczki/awesome-graph-classification)
 - [Awesome Community Detection](https://github.com/benedekrozemberczki/awesome-community-detection)
 - [CreativeAi's Machine Learning](http://www.creativeai.net/?cat%5B0%5D=machine-learning)
+- [Machine Learning Online Courses](https://classpert.com/machine-learning)
 
 ## Games
 - [Halite: A.I. Coding Game](https://halite.io/)


### PR DESCRIPTION
This commit add online courses link to en and pt-br versions to this awesome path for ML mastery  :) This link points to Classpert, which is a search engine for online courses. Courses themselves are from top e-learning platforms like Udemy, Coursera, Skillshare, Pluralsight, etc.